### PR TITLE
BRGD-181 Consume Parameters Endpoint

### DIFF
--- a/.github/releases/v0.2.0-beta1.md
+++ b/.github/releases/v0.2.0-beta1.md
@@ -1,0 +1,2 @@
+- The x-display-name OpenAPI field is now used to determine property names, if present.
+- The command parser now consumes the parameters endpoint instead of parser restrictions, as the parser restrictions endpoint will be removed soon.

--- a/src/ClientGenerator/Program.cs
+++ b/src/ClientGenerator/Program.cs
@@ -80,6 +80,7 @@ namespace Brighid.Commands.ClientGenerator
                     TemplateDirectory = templateDirectory,
                     Namespace = "Brighid.Commands.Client",
                     JsonLibrary = CSharpJsonLibrary.SystemTextJson,
+                    PropertyNameGenerator = new PropertyNameGenerator(),
                 },
             };
 

--- a/src/ClientGenerator/PropertyNameGenerator.cs
+++ b/src/ClientGenerator/PropertyNameGenerator.cs
@@ -1,0 +1,19 @@
+using NJsonSchema;
+using NJsonSchema.CodeGeneration;
+
+namespace Brighid.Commands.ClientGenerator
+{
+    /// <inheritdoc />
+    public class PropertyNameGenerator : IPropertyNameGenerator
+    {
+        /// <inheritdoc />
+        public string Generate(JsonSchemaProperty property)
+        {
+            object? displayName = null;
+            property.ExtensionData?.TryGetValue("x-display-name", out displayName);
+
+            var result = (string?)displayName ?? property.Name;
+            return char.ToUpper(result[0]) + result[1..];
+        }
+    }
+}


### PR DESCRIPTION
- The x-display-name OpenAPI field is now used to determine property names, if present.
- The command parser now consumes the parameters endpoint instead of parser restrictions, as the parser restrictions endpoint will be removed soon.