### PR TITLE
BRGD-219 Clear All Cached Command Parameters

### DIFF
--- a/.github/releases/v0.2.0-beta6.md
+++ b/.github/releases/v0.2.0-beta6.md
@@ -1,0 +1,8 @@
+## Enhancements
+
+- New method: IBrighidCommandsCache.ClearAllParameters added for clearing all cached parameters.
+- New Method: IBrighidCommandsCache.ParametersExist added for checking if a command's parameters have been cached.
+
+## Breaking Changes
+
+- IBrighidCommandsCache.GetOrCreateAsync has been renamed to IBrighidCommandsCache.GetOrCreateParametersAsync

--- a/src/Client/DefaultBrighidCommandsCache.cs
+++ b/src/Client/DefaultBrighidCommandsCache.cs
@@ -9,7 +9,10 @@ namespace Brighid.Commands.Client
     /// <inheritdoc />
     public class DefaultBrighidCommandsCache : MemoryCache, IBrighidCommandsCache
     {
-        private const string ParametersPrefix = "Parameters.";
+        private const string ParametersPrefix = "Parameters";
+        private const char Delimiter = '.';
+        private readonly List<string> cachedParameters = new();
+        private readonly PostEvictionCallbackRegistration evictionRegistration;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="DefaultBrighidCommandsCache" /> class.
@@ -17,18 +20,60 @@ namespace Brighid.Commands.Client
         public DefaultBrighidCommandsCache()
             : base(new MemoryCacheOptions { SizeLimit = 1000 })
         {
+            evictionRegistration = new(EvictionCallback);
+        }
+
+        /// <inheritdoc />
+        public void ClearAllParameters()
+        {
+            foreach (var cachedParameter in cachedParameters)
+            {
+                Remove(cachedParameter);
+            }
+        }
+
+        /// <inheritdoc />
+        public bool ParametersExist(string name)
+        {
+            return TryGetValue($"{ParametersPrefix}{Delimiter}{name}", out _);
         }
 
         /// <inheritdoc />
         public void ClearParameters(string name)
         {
-            Remove($"{ParametersPrefix}{name}");
+            Remove($"{ParametersPrefix}{Delimiter}{name}");
         }
 
         /// <inheritdoc />
-        public Task<ICollection<CommandParameter>> GetOrCreateAsync(string name, Func<ICacheEntry, Task<ICollection<CommandParameter>>> factory)
+        public Task<ICollection<CommandParameter>> GetOrCreateParametersAsync(string name, Func<ICacheEntry, Task<ICollection<CommandParameter>>> factory)
         {
-            return (this as IMemoryCache).GetOrCreateAsync($"{ParametersPrefix}{name}", factory);
+            var parameterKey = $"{ParametersPrefix}{Delimiter}{name}";
+            return (this as IMemoryCache).GetOrCreateAsync(parameterKey, (ICacheEntry entry) =>
+            {
+                cachedParameters.Add(parameterKey);
+                entry.PostEvictionCallbacks.Add(evictionRegistration);
+                return factory(entry);
+            });
+        }
+
+        private void EvictionCallback(object key, object value, EvictionReason reason, object state)
+        {
+            var keyString = (string)key;
+            var prefix = keyString.Split(Delimiter)[0];
+
+            switch (prefix)
+            {
+                case ParametersPrefix: cachedParameters.Remove(keyString); break;
+                default: break;
+            }
+        }
+
+        private class PostEvictionCallbackRegistration : Microsoft.Extensions.Caching.Memory.PostEvictionCallbackRegistration
+        {
+            public PostEvictionCallbackRegistration(PostEvictionDelegate evictionCallback)
+            {
+                EvictionCallback = evictionCallback;
+            }
         }
     }
 }

--- a/src/Client/IBrighidCommandsCache.cs
+++ b/src/Client/IBrighidCommandsCache.cs
@@ -12,10 +12,22 @@ namespace Brighid.Commands.Client
     public interface IBrighidCommandsCache
     {
         /// <summary>
+        /// Clears out all cached parameters.
+        /// </summary>
+        void ClearAllParameters();
+
+        /// <summary>
         /// Clears out parameters cached for a specific command by name.
         /// </summary>
         /// <param name="name">The name of the command to clear out parameters for.</param>
         void ClearParameters(string name);
+
+        /// <summary>
+        /// Checks to see if a commands' parameters are cached or not.
+        /// </summary>
+        /// <param name="name">The name of the command to check if its parameters are cached.</param>
+        /// <returns>True if the parameters are cached, or false if not.</returns>
+        bool ParametersExist(string name);
 
         /// <summary>
         /// Gets cached command parameters or creates new ones.
@@ -23,6 +35,6 @@ namespace Brighid.Commands.Client
         /// <param name="name">The name of the command to cache parameters for.</param>
         /// <param name="factory">Factory for creating a new cache entry.</param>
         /// <returns>The resulting command parameters.</returns>
-        Task<ICollection<CommandParameter>> GetOrCreateAsync(string name, Func<ICacheEntry, Task<ICollection<CommandParameter>>> factory);
+        Task<ICollection<CommandParameter>> GetOrCreateParametersAsync(string name, Func<ICacheEntry, Task<ICollection<CommandParameter>>> factory);
     }
 }

--- a/src/Client/Parser/Services/CommandParserStateMachine.cs
+++ b/src/Client/Parser/Services/CommandParserStateMachine.cs
@@ -155,7 +155,7 @@ namespace Brighid.Commands.Client.Parser
         {
             try
             {
-                var parameters = await cache.GetOrCreateAsync(Result.Name, async (entry) =>
+                var parameters = await cache.GetOrCreateParametersAsync(Result.Name, async (entry) =>
                 {
                     var response = await commandsClient.GetCommandParameters(Result.Name, options.ClientRequestOptions, cancellationToken);
                     entry.SetPriority(CacheItemPriority.Normal);

--- a/tests/DefaultBrighidCommandsCacheTests.cs
+++ b/tests/DefaultBrighidCommandsCacheTests.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+using FluentAssertions;
+
+using Microsoft.Extensions.Caching.Memory;
+
+using NUnit.Framework;
+
+namespace Brighid.Commands.Client
+{
+    public class DefaultBrighidCommandsCacheTests
+    {
+        [TestFixture]
+        public class ClearAllParametersTests
+        {
+            [Test, Auto]
+            public async Task ShouldRemoveAllCachedParameters(
+                string keyA,
+                string keyB,
+                [Target] DefaultBrighidCommandsCache cache
+            )
+            {
+                await cache.GetOrCreateParametersAsync(keyA, Factory);
+                await cache.GetOrCreateParametersAsync(keyB, Factory);
+
+                cache.ClearAllParameters();
+
+                cache.ParametersExist(keyA).Should().BeFalse();
+                cache.ParametersExist(keyB).Should().BeFalse();
+            }
+
+            private Task<ICollection<CommandParameter>> Factory(ICacheEntry entry)
+            {
+                entry.SetPriority(CacheItemPriority.Normal);
+                entry.SetAbsoluteExpiration(TimeSpan.FromHours(1));
+                entry.SetSize(1);
+                return Task.FromResult<ICollection<CommandParameter>>(new List<CommandParameter>());
+            }
+        }
+    }
+}


### PR DESCRIPTION
* Adds a method for clearing all cached parameters.
* Adds a method for checking if a command's parameters are cached.
* Renames IBrighidCommandsCache.GetOrCreateAsync to GetOrCreateParametersAsync