### PR TITLE
BRGD-219 Fix Synchronization Problems with Cached Parameters List

### DIFF
--- a/src/Client/DefaultBrighidCommandsCache.cs
+++ b/src/Client/DefaultBrighidCommandsCache.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 
 using Microsoft.Extensions.Caching.Memory;
@@ -26,7 +27,7 @@ namespace Brighid.Commands.Client
         /// <inheritdoc />
         public void ClearAllParameters()
         {
-            foreach (var cachedParameter in cachedParameters)
+            foreach (var cachedParameter in cachedParameters.ToList())
             {
                 Remove(cachedParameter);
             }


### PR DESCRIPTION
Fixes an issue with the cached parameters list where calling clearallparameters could sometimes result in an exception, if an element is deleted while traversing the list.