### PR TITLE
Update Swagger to spec version 1.0.886.30625

### DIFF
--- a/swagger.json
+++ b/swagger.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.1",
   "info": {
     "title": "Brighid Commands",
-    "version": "1.0.880.51939"
+    "version": "1.0.886.30625"
   },
   "servers": [
     {


### PR DESCRIPTION
This is an automated update of the swagger spec to spec version 1.0.886.30625.